### PR TITLE
Add granite and geoclue as dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,6 +5,8 @@ Maintainer: elementary, Inc. <builds@elementary.io>
 Build-Depends: debhelper (>= 10.5.1),
                libaccountsservice-dev,
                libdbus-1-dev,
+               libgranite-dev,
+               libgeoclue-2-dev
                meson,
                valac
 Standards-Version: 4.1.1


### PR DESCRIPTION
Missing dependencies causes [build failing on Launchpad](https://launchpadlibrarian.net/499889882/buildlog_ubuntu-focal-amd64.io.elementary.settings-daemon_1.0.0+r9+pkg3~daily~ubuntu6.0.1_BUILDING.txt.gz)
