### PR TITLE
build: add glib dependency

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -4,6 +4,8 @@ project('io.elementary.settings-daemon',
     license: 'GPL3',
 )
 
+gio_dep = dependency ('gio-2.0')
+glib_dep = dependency('glib-2.0')
 granite_dep = dependency('granite', version: '>= 5.3.0')
 
 cc = meson.get_compiler('c')

--- a/src/meson.build
+++ b/src/meson.build
@@ -22,10 +22,11 @@ executable(
     sources,
     config_file,
     dependencies: [
-        dependency ('gio-2.0'),
+        gio_dep,
+        glib_dep,
         granite_dep,
+        libgeoclue_dep,
         m_dep,
-        libgeoclue_dep
     ],
     install: true,
 )


### PR DESCRIPTION
GLib.Variant is used in the code and that comes from glib-2.0.

Not sure about making version constraints on gio and glib, though. It should be done in the future.