### PR TITLE
Add GSetting for dark style preference

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# EditorConfig <http://EditorConfig.org>
+root = true
+
+# elementary defaults
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = tab
+indent_style = space
+insert_final_newline = true
+max_line_length = 80
+tab_width = 4
+
+[{*.xml,*.xml.in,*.yml}]
+tab_width = 2

--- a/data/io.elementary.settings-daemon.gschema.xml
+++ b/data/io.elementary.settings-daemon.gschema.xml
@@ -1,31 +1,45 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schemalist>
-    <enum id="PreferDarkScheduleType">
-        <value nick='disabled' value='0'/>
-        <value nick='sunset-to-sunrise' value='1'/>
-        <value nick='manual' value='2'/>
-    </enum>
+  <enum id="PreferDarkScheduleType">
+    <value nick='disabled' value='0'/>
+    <value nick='sunset-to-sunrise' value='1'/>
+    <value nick='manual' value='2'/>
+  </enum>
 
-    <schema path="/io/elementary/settings-daemon/prefers-color-scheme/" id="io.elementary.settings-daemon.prefers-color-scheme">
-        <key enum="PreferDarkScheduleType" name="prefer-dark-schedule">
-			<default>'disabled'</default>
-			<summary>Algorithm for prefer dark schedule</summary>
-			<description>Choose the algorithm used for prefer dark schedule.</description>
-		</key>
-	    <key type="d" name="prefer-dark-schedule-from">
-            <default>20.0</default>
-            <summary>The start time</summary>
-            <description></description>
-        </key>
-        <key type="d" name="prefer-dark-schedule-to">
-            <default>6.0</default>
-            <summary>The stop time</summary>
-            <description></description>
-        </key>
-        <key type="(dd)" name="last-coordinates">
-            <default>(91,181)</default>
-            <summary>The last detected position</summary>
-            <description>When location services are available this represents the last detected location. The default value is an invalid value to ensure it is always updated at startup.</description>
-        </key>
-    </schema>
+  <enum id="ColorSchemes">
+    <value nick='no-preference' value='0'/>
+    <value nick='dark' value='1'/>
+    <value nick='light' value='2'/>
+  </enum>
+
+  <schema path="/io/elementary/settings-daemon/prefers-color-scheme/" id="io.elementary.settings-daemon.prefers-color-scheme">
+    <key enum="PreferDarkScheduleType" name="prefer-dark-schedule">
+      <default>'disabled'</default>
+      <summary>Algorithm for prefer dark schedule</summary>
+      <description>Choose the algorithm used for prefer dark schedule.</description>
+    </key>
+    <key type="d" name="prefer-dark-schedule-from">
+      <default>20.0</default>
+      <summary>The start time</summary>
+      <description></description>
+    </key>
+    <key type="d" name="prefer-dark-schedule-to">
+      <default>6.0</default>
+      <summary>The stop time</summary>
+      <description></description>
+    </key>
+    <key type="(dd)" name="last-coordinates">
+      <default>(91,181)</default>
+      <summary>The last detected position</summary>
+      <description>When location services are available this represents the last detected location. The default value is an invalid value to ensure it is always updated at startup.</description>
+    </key>
+  </schema>
+
+  <schema path="/org/freedesktop/" id="org.freedesktop">
+    <key enum="ColorSchemes" name="prefers-color-scheme">
+      <default>'no-preference'</default>
+      <summary>Prefers color scheme</summary>
+      <description>The user's preferred visual style for the user interface.</description>
+    </key>
+  </schema>
 </schemalist>

--- a/src/Backends/PrefersColorSchemeSettings.vala
+++ b/src/Backends/PrefersColorSchemeSettings.vala
@@ -44,8 +44,6 @@ public class SettingsDaemon.Backends.PrefersColorSchemeSettings : Object {
         }
 
         color_settings.changed["prefer-dark-schedule"].connect (update_timer);
-
-
         desktop_settings.bind ("prefers-color-scheme", granite_settings, "prefers-color-scheme", SettingsBindFlags.SET);
 
         update_timer ();

--- a/src/Backends/PrefersColorSchemeSettings.vala
+++ b/src/Backends/PrefersColorSchemeSettings.vala
@@ -23,7 +23,6 @@ public class SettingsDaemon.Backends.PrefersColorSchemeSettings : Object {
     public unowned PantheonShell.Pantheon.AccountsService accounts_service { get; construct; }
 
     private Settings color_settings;
-    private Settings desktop_settings;
     private double sunrise = -1.0;
     private double sunset = -1.0;
 
@@ -35,7 +34,8 @@ public class SettingsDaemon.Backends.PrefersColorSchemeSettings : Object {
 
     construct {
         color_settings = new Settings ("io.elementary.settings-daemon.prefers-color-scheme");
-        desktop_settings = new Settings ("org.freedesktop");
+        var desktop_settings = new Settings ("org.freedesktop");
+        var granite_settings = Granite.Settings.get_default ();
 
         var schedule = color_settings.get_string ("prefer-dark-schedule");
         if (schedule == "sunset-to-sunrise") {
@@ -44,21 +44,11 @@ public class SettingsDaemon.Backends.PrefersColorSchemeSettings : Object {
         }
 
         color_settings.changed["prefer-dark-schedule"].connect (update_timer);
-        // TODO: Basically, accounts_service.changed["prefers-color-scheme"].connect (update_color_scheme);
+
+
+        desktop_settings.bind ("prefers-color-scheme", granite_settings, "prefers-color-scheme", SettingsBindFlags.SET);
 
         update_timer ();
-        update_color_scheme ();
-    }
-
-    private void update_color_scheme () {
-        switch (accounts_service.prefers_color_scheme) {
-            case Granite.Settings.ColorScheme.DARK:
-                desktop_settings.set_string ("prefers-color-scheme", "dark");
-                break;
-            default:
-                desktop_settings.set_string ("prefers-color-scheme", "no-preference");
-                break;
-        }
     }
 
     private void update_timer () {

--- a/src/Backends/PrefersColorSchemeSettings.vala
+++ b/src/Backends/PrefersColorSchemeSettings.vala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2020 elementary, Inc. (https://elementary.io)
+* Copyright 2020–2021 elementary, Inc. (https://elementary.io)
 *
 * This program is free software; you can redistribute it and/or
 * modify it under the terms of the GNU General Public
@@ -42,6 +42,14 @@ public class SettingsDaemon.Backends.PrefersColorSchemeSettings : GLib.Object {
             var variant = color_settings.get_value ("last-coordinates");
             on_location_updated (variant.get_child_value (0).get_double (), variant.get_child_value (1).get_double ());
         }
+
+        var desktop_settings = new GLib.Settings ("org.freedesktop");
+        desktop_settings.bind (
+            "prefers-color-scheme",
+            accounts_service,
+            "prefers-color-scheme",
+            SettingsBindFlags.DEFAULT
+        );
 
         update ();
     }


### PR DESCRIPTION
Fixes #16. Follows the same terminology used elsewhere and documented at https://github.com/elementary/os/wiki/Dark-Style-Preference. 

While I was here I bumped copyright, fixed whitespace (Mixed tabs and spaces! Boo! Hiss!), added .editorconfig to prevent that from happening in the future, and renamed `update ()` to `update_timer ()` so it's more clear what it does.

- [x] Add GSetting
- [x] Mirror AccountsService preference to the GSetting