### PR TITLE
Use systemd-tmpfiles to allow Downloads folder housekeeping

### DIFF
--- a/data/io.elementary.settings-daemon.gschema.xml
+++ b/data/io.elementary.settings-daemon.gschema.xml
@@ -43,7 +43,7 @@
     </key>
     <key type="i" name="downloads-max-age-days">
       <default>30</default>
-      <summary>How old an item should be in the downloads folder before it is cleaned up.</summary>
+      <summary>How many days an item should be in the downloads folder before it is cleaned up.</summary>
       <description></description>
     </key>
   </schema>

--- a/data/io.elementary.settings-daemon.gschema.xml
+++ b/data/io.elementary.settings-daemon.gschema.xml
@@ -35,6 +35,18 @@
     </key>
   </schema>
 
+  <schema path="/io/elementary/settings-daemon/housekeeping/" id="io.elementary.settings-daemon.housekeeping">
+    <key type="b" name="cleanup-downloads-folder">
+      <default>false</default>
+      <summary>Whether the Downloads folder should be automatically cleaned up.</summary>
+      <description></description>
+    </key>
+    <key type="i" name="downloads-max-age-days">
+      <default>30</default>
+      <summary>How old an item should be in the downloads folder before it is cleaned up.</summary>
+      <description></description>
+    </key>
+  </schema>
   <schema path="/org/freedesktop/" id="org.freedesktop">
     <key enum="ColorSchemes" name="prefers-color-scheme">
       <default>'no-preference'</default>

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -38,10 +38,14 @@ public class SettingsDaemon.Application : GLib.Application {
 
     private Backends.PrefersColorSchemeSettings prefers_color_scheme_settings;
 
+    private Backends.Housekeeping housekeeping;
+
     construct {
         application_id = Build.PROJECT_NAME;
 
         add_main_option_entries (OPTIONS);
+
+        housekeeping = new Backends.Housekeeping ();
     }
 
     public override int handle_local_options (VariantDict options) {

--- a/src/Backends/Housekeeping.vala
+++ b/src/Backends/Housekeeping.vala
@@ -38,8 +38,9 @@ public class SettingsDaemon.Backends.Housekeeping : GLib.Object {
 
         if (housekeeping_settings.get_boolean ("cleanup-downloads-folder")) {
             enable_systemd_tmpfiles.begin ();
-            write_systemd_tmpfiles_config.begin ();
         }
+
+        write_systemd_tmpfiles_config.begin ();
     }
 
     // The systemd-tmpfiles-clean user timer that runs every day and cleans up files based on user config files

--- a/src/Backends/Housekeeping.vala
+++ b/src/Backends/Housekeeping.vala
@@ -1,0 +1,139 @@
+/*
+* Copyright 2021 elementary, Inc. (https://elementary.io)
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public
+* License as published by the Free Software Foundation; either
+* version 3 of the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* General Public License for more details.
+*
+* You should have received a copy of the GNU General Public
+* License along with this program; if not, write to the
+* Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+* Boston, MA 02110-1301 USA
+*
+*/
+
+[DBus (name = "org.freedesktop.systemd1.Manager")]
+public interface SystemdManager : GLib.Object {
+    public abstract async string get_unit_file_state (string unit_file) throws GLib.Error;
+    public abstract async void enable_unit_files (string[] unit_files, bool runtime, bool replace) throws GLib.Error;
+    public abstract async void start_unit (string name, string mode) throws GLib.Error;
+}
+
+public class SettingsDaemon.Backends.Housekeeping : GLib.Object {
+    private GLib.Settings housekeeping_settings;
+    private SystemdManager? systemd;
+
+    construct {
+        housekeeping_settings = new GLib.Settings ("io.elementary.settings-daemon.housekeeping");
+        housekeeping_settings.changed.connect (() => {
+            enable_systemd_tmpfiles.begin ();
+            write_systemd_tmpfiles_config.begin ();
+        });
+
+        if (housekeeping_settings.get_boolean ("cleanup-downloads-folder")) {
+            enable_systemd_tmpfiles.begin ();
+            write_systemd_tmpfiles_config.begin ();
+        }
+    }
+
+    // The systemd-tmpfiles-clean user timer that runs every day and cleans up files based on user config files
+    // is disabled by default (at least on Ubuntu 20.04), so we have some code to check and enable it if necessary
+    private async void enable_systemd_tmpfiles () {
+        if (systemd == null) {
+            try {
+                systemd = yield GLib.Bus.get_proxy (
+                    GLib.BusType.SESSION,
+                    "org.freedesktop.systemd1",
+                    "/org/freedesktop/systemd1"
+                );
+            } catch (Error e) {
+                warning ("Unable to connect to systemd to see if systemd-tmpfiles service is enabled: %s", e.message);
+                return;
+            }
+        }
+
+        try {
+            // Already enabled, nothing to do
+            if ((yield systemd.get_unit_file_state ("systemd-tmpfiles-clean.timer")) == "enabled") {
+                return;
+            }
+
+            yield systemd.enable_unit_files ({"systemd-tmpfiles-clean.timer"}, false, false);
+            yield systemd.start_unit ("systemd-tmpfiles-clean.timer", "fail");
+        } catch (Error e) {
+            warning ("Error getting or setting systemd-tmpfiles enabled state: %s", e.message);
+        }
+    }
+
+    // Write (or delete) a config file in ~/.config/user-tmpfiles.d to configure the systemd timer for cleaning up the user's
+    // downloads folder based on the configured age in GSettings
+    private async void write_systemd_tmpfiles_config () {
+        var config_path = GLib.Path.build_filename (
+            GLib.Environment.get_user_config_dir (),
+            "user-tmpfiles.d",
+            "io.elementary.settings-daemon.downloads-folder.conf"
+        );
+
+        var downloads_cleanup_enabled = housekeeping_settings.get_boolean ("cleanup-downloads-folder");
+
+        var config_file = GLib.File.new_for_path (config_path);
+        if (!config_file.get_parent ().query_exists ()) {
+            if (!downloads_cleanup_enabled) {
+                // No point continuing if cleanup isn't enabled
+                return;
+            }
+
+            try {
+                config_file.get_parent ().make_directory_with_parents ();
+            } catch (Error e) {
+                warning ("Error creating directory for systemd-tmpfiles: %s", e.message);
+                return;
+            }
+        }
+
+        int downloads_cleanup_days = housekeeping_settings.get_int ("downloads-max-age-days");
+
+        // Delete the systemd-tmpfiles config if download cleanup is disabled
+        if (!downloads_cleanup_enabled || downloads_cleanup_days < 1) {
+            try {
+                yield config_file.delete_async ();
+            } catch (Error e) {
+                if (!(e is GLib.IOError.NOT_FOUND)) {
+                    warning ("Unable to delete systemd-tmpfiles config: %s", e.message);
+                }
+            }
+
+            return;
+        }
+
+        var downloads_folder = GLib.Environment.get_user_special_dir (
+            GLib.UserDirectory.DOWNLOAD
+        );
+
+        FileIOStream config_stream;
+        try {
+            config_stream = yield config_file.replace_readwrite_async (null, false, FileCreateFlags.NONE);
+        } catch (Error e) {
+            warning ("Unable to open systemd-tmpfiles config file for writng: %s", e.message);
+            return;
+        }
+
+        // See https://www.freedesktop.org/software/systemd/man/tmpfiles.d.html for details
+        // Results in a config line like:
+        // e "/home/david/Downloads" - - - 30d
+        string config = "e \"%s\" - - - %dd".printf (downloads_folder, downloads_cleanup_days);
+
+        FileOutputStream os = config_stream.output_stream as FileOutputStream;
+        try {
+            yield os.write_all_async (config.data, GLib.Priority.DEFAULT, null, null);
+        } catch (Error e) {
+            warning ("Unable to write systemd-tmpfiles config: %s", e.message);
+        }
+    }
+}

--- a/src/meson.build
+++ b/src/meson.build
@@ -12,6 +12,7 @@ sources = files(
     'AccountsService.vala',
     'Application.vala',
     'SessionManager.vala',
+    'Backends/Housekeeping.vala',
     'Backends/KeyboardSettings.vala',
     'Backends/PrefersColorSchemeSettings.vala',
     'Utils/SunriseSunsetCalculator.vala',


### PR DESCRIPTION
Based on @cassidyjames 's tweet I saw: https://twitter.com/CassidyJames/status/1382045710883774466

It sounds like gsd-housekeeping may be killed in favour of systemd-tmpfiles at some point anyway, so we can probably get ahead of the curve here.

Adds two new GSettings keys to the settings-daemon namespace that allow enabling housekeeping of the user's downloads folder. The maximum age of files to be kept is configurable.

This uses systemd-tmpfiles to do the heavy lifting of running on a schedule and actually deleting the files.

I'll leave it up to someone else to develop the UI in switchboard and initial setup if we decide we want this.