### PR TITLE
Fix Range Check After Midnight When `from > to`

### DIFF
--- a/src/Backends/PrefersColorSchemeSettings.vala
+++ b/src/Backends/PrefersColorSchemeSettings.vala
@@ -144,7 +144,7 @@ public class SettingsDaemon.Backends.PrefersColorSchemeSettings : Object {
     public static bool is_in_time_window (double time_double, double from, double to) {
         // PM to AM
         if (from > to) {
-            return (time_double >= from && time_double <= (to + 24));
+            return time_double < to ? time_double <= from : time_double >= from;
         }
 
         // AM to AM, PM to PM, AM to PM


### PR DESCRIPTION
Fixes elementary/switchboard-plug-pantheon-shell#273.