### PR TITLE
Load left handed mode from settings-daemon

### DIFF
--- a/src/Backends/MouseSettings.vala
+++ b/src/Backends/MouseSettings.vala
@@ -34,6 +34,7 @@ public class SettingsDaemon.Backends.MouseSettings : GLib.Object {
         touchpad_settings = new GLib.Settings ("org.gnome.desktop.peripherals.touchpad");
         interface_settings = new GLib.Settings ("org.gnome.desktop.interface");
 
+        // This is used by installer to set left-handed mode
         if (accounts_service.left_handed != mouse_settings.get_boolean ("left-handed")) {
             mouse_settings.set_boolean ("left-handed", accounts_service.left_handed);
         }

--- a/src/Backends/MouseSettings.vala
+++ b/src/Backends/MouseSettings.vala
@@ -34,6 +34,10 @@ public class SettingsDaemon.Backends.MouseSettings : GLib.Object {
         touchpad_settings = new GLib.Settings ("org.gnome.desktop.peripherals.touchpad");
         interface_settings = new GLib.Settings ("org.gnome.desktop.interface");
 
+        if (accounts_service.left_handed != mouse_settings.get_boolean ("left-handed")) {
+            mouse_settings.set_boolean ("left-handed", accounts_service.left_handed);
+        }
+
         sync_gsettings_to_accountsservice ();
 
         mouse_settings.changed.connect ((key) => {


### PR DESCRIPTION
I want to return this back, because I suspect this is used by installer to set left handed mode. (This was removed in #66)