### PR TITLE
Fix installing check-for-firmware-updates files in NixOS

### DIFF
--- a/data/io.elementary.settings-daemon.check-for-firmware-updates.service.in
+++ b/data/io.elementary.settings-daemon.check-for-firmware-updates.service.in
@@ -5,4 +5,4 @@ After=network.target network-online.target systemd-networkd.service NetworkManag
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/busctl --user call io.elementary.settings-daemon /io/elementary/settings_daemon org.freedesktop.Application ActivateAction sava{sv} "check-firmware-updates" 0 0
+ExecStart=@busctl_path@ --user call io.elementary.settings-daemon /io/elementary/settings_daemon org.freedesktop.Application ActivateAction sava{sv} "check-firmware-updates" 0 0

--- a/data/meson.build
+++ b/data/meson.build
@@ -42,18 +42,33 @@ i18n.merge_file(
     install_dir: get_option('datadir') / 'metainfo',
 )
 
-systemd = dependency('systemd')
-systemd_system_unit_dir = systemd.get_variable('systemdsystemunitdir')
+busctl_path = get_option('busctlpath')
+systemd_system_unit_dir = get_option('systemdsystemunitdir')
 
-install_data(
-    meson.project_name() + '.check-for-firmware-updates.service',
-    install_dir: systemd_system_unit_dir
-)
+if systemd_system_unit_dir != 'no'
+    systemd = dependency('systemd')
+    if systemd_system_unit_dir == ''
+        systemd_system_unit_dir = systemd.get_variable('systemdsystemunitdir', pkgconfig_define: ['rootprefix', prefix])
+    endif
+    if busctl_path == ''
+        busctl_path = systemd.get_variable('prefix') / 'bin' / 'busctl'
+    endif
 
-install_data(
-    meson.project_name() + '.check-for-firmware-updates.timer',
-    install_dir: systemd_system_unit_dir
-)
+    service_config = configuration_data()
+    service_config.set('busctl_path', busctl_path)
+
+    configure_file(
+        input: meson.project_name() + '.check-for-firmware-updates.service.in',
+        output: meson.project_name() + '.check-for-firmware-updates.service',
+        configuration: service_config,
+        install_dir: systemd_system_unit_dir
+    )
+
+    install_data(
+        meson.project_name() + '.check-for-firmware-updates.timer',
+        install_dir: systemd_system_unit_dir
+    )
+endif
 
 icon_sizes = ['24', '32', '48', '64', '128']
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,1 +1,3 @@
+option('busctlpath', type: 'string', value: '', description: 'custom path to busctl executable')
+option('systemdsystemunitdir', type: 'string', value: '', description: 'custom directory for systemd system units, or \'no\' to disable')
 option('systemduserunitdir', type: 'string', value: '', description: 'custom directory for systemd user units, or \'no\' to disable')


### PR DESCRIPTION
(review with hide whitespace)

As a weird distro, we install packages in their own separate prefixes, which means we don't have `/usr/bin/busctl`, and we cannot install files to systemd's prefix.

(I can kill the `busctlpath` meson options if preferred, since we are not using `find_program` I assume cross compilation *should* be fine here?)

```
$ find | grep check-for-firmware-updates       
./lib/systemd/system/io.elementary.settings-daemon.check-for-firmware-updates.service
./lib/systemd/system/io.elementary.settings-daemon.check-for-firmware-updates.timer

$ cat ./lib/systemd/system/io.elementary.settings-daemon.check-for-firmware-updates.service | grep ExecStart
ExecStart=/nix/store/lhpz4ywr4dhbcxx688piqa7cv6vh15fd-systemd-253.5/bin/busctl --user call io.elementary.settings-daemon /io/elementary/settings_daemon org.freedesktop.Application ActivateAction sava{sv} "check-firmware-updates" 0 0
```