### PR TITLE
Fix installing autostart files in NixOS

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -4,10 +4,11 @@ install_data(
     rename: meson.project_name() + '.desktop'
 )
 
+fs = import('fs')
 meson.add_install_script(
     symlink,
-    join_paths(get_option('datadir'), 'applications', meson.project_name() + '.desktop'),
-    join_paths(get_option('sysconfdir'), 'xdg', 'autostart', meson.project_name() + '.desktop'),
+    join_paths(datadir, 'applications', meson.project_name() + '.desktop'),
+    join_paths(fs.is_absolute(sysconfdir) ? sysconfdir : prefix / sysconfdir, 'xdg', 'autostart', meson.project_name() + '.desktop'),
 )
 
 dbus_dep = dependency('dbus-1')

--- a/meson.build
+++ b/meson.build
@@ -2,6 +2,7 @@ project('io.elementary.settings-daemon',
     'c', 'vala',
     version: '1.3.0',
     license: 'GPL3',
+    meson_version: '>= 0.54.0',
 )
 
 fwupd_dep = dependency('fwupd')
@@ -46,6 +47,7 @@ config_dep = declare_dependency(
 
 prefix = get_option('prefix')
 datadir = join_paths(prefix, get_option('datadir'))
+sysconfdir = get_option('sysconfdir')
 
 symlink = join_paths(meson.current_source_dir (), 'meson', 'create-symlink.sh')
 


### PR DESCRIPTION
`sysconfdir` can be absolute or relative, trying to ensure the file is actually installed to the prefix in NixOS.

(This is not installed for us before the change. Note that [`is_absolute`](https://mesonbuild.com/Fs-module.html#is_absolute) needs meson 0.54)