### PR TITLE
Add weather alerts

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -9,6 +9,8 @@ fwupd_dep = dependency('fwupd')
 gio_dep = dependency ('gio-2.0')
 glib_dep = dependency('glib-2.0')
 granite_dep = dependency('granite', version: '>= 5.3.0')
+json_dep = dependency('json-glib-1.0')
+soup_dep = dependency('libsoup-3.0')
 i18n = import('i18n')
 gettext_name = meson.project_name()
 

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -17,6 +17,8 @@ public sealed class SettingsDaemon.Application : Gtk.Application {
 
     private Backends.Housekeeping housekeeping;
 
+    private Backends.WeatherAlerts weather_alerts;
+
     private const string FDO_ACCOUNTS_NAME = "org.freedesktop.Accounts";
     private const string FDO_ACCOUNTS_PATH = "/org/freedesktop/Accounts";
 
@@ -51,6 +53,8 @@ public sealed class SettingsDaemon.Application : Gtk.Application {
         base.startup ();
 
         housekeeping = new Backends.Housekeeping ();
+
+        weather_alerts = new Backends.WeatherAlerts ();
 
         var check_firmware_updates_action = new GLib.SimpleAction ("check-firmware-updates", null);
         check_firmware_updates_action.activate.connect (check_firmware_updates);

--- a/src/Backends/WeatherAlerts.vala
+++ b/src/Backends/WeatherAlerts.vala
@@ -109,7 +109,7 @@ public class SettingsDaemon.Backends.WeatherAlerts : Object {
                         )
                     );
                     notification.set_icon (new ThemedIcon ("dialog-error"));
-                    notification.set_body (alert_obj.get_string_member ("desc"));
+                    notification.set_body (alert_obj.get_string_member ("headline"));
 
                     app.send_notification (alert_obj.get_string_member ("headline"), notification);
                 });

--- a/src/Backends/WeatherAlerts.vala
+++ b/src/Backends/WeatherAlerts.vala
@@ -1,0 +1,123 @@
+public class SettingsDaemon.Backends.WeatherAlerts : Object {
+    private const string API_KEY = "9d9c2fa1c0024a4b9fc152215232108";
+
+    private double latitude;
+    private double longitude;
+
+    construct {
+        init_location.begin (() => {
+            update_alerts.begin ();
+        });
+
+        Timeout.add_seconds (3600, () => {
+            update_alerts.begin ();
+            return Source.CONTINUE;
+        });
+    }
+
+    private async void init_location () {
+        try {
+            var simple = yield new GClue.Simple (Build.PROJECT_NAME, GClue.AccuracyLevel.CITY, null);
+
+            simple.notify["location"].connect (() => {
+                latitude = simple.location.latitude;
+                longitude = simple.location.longitude;
+                update_alerts.begin ();
+            });
+
+            latitude = simple.location.latitude;
+            longitude = simple.location.longitude;
+        } catch (Error e) {
+            warning ("Failed to connect to GeoClue2 service: %s", e.message);
+            return;
+        }
+    }
+
+    private async void update_alerts () {
+        var session = new Soup.Session ();
+
+        var msg = new Soup.Message (
+            "GET",
+            "http://api.weatherapi.com/v1/forecast.json?key=%s&q=%s,%s&days=1&aqi=no&alerts=yes".printf (
+                API_KEY,
+                latitude.to_string (),
+                longitude.to_string ()
+            )
+        );
+
+        msg.finished.connect (() => {
+            if (msg.status_code != Soup.Status.OK) {
+                warning ("Failed with status code %u (%s)", msg.status_code, Soup.Status.get_phrase (msg.status_code));
+            }
+        });
+
+        try {
+            var bytes = yield session.send_and_read_async (msg, Priority.DEFAULT, null);
+            var json_parser = new Json.Parser ();
+            try {
+                string data = (string) bytes.get_data ();
+                json_parser.load_from_data (data);
+                var node = json_parser.get_root ();
+                if (node == null) {
+                    warning ("No JSON root node found!");
+                    return;
+                }
+
+                unowned var obj = node.get_object ();
+                if (obj == null) {
+                    warning ("No root object found!");
+                    return;
+                }
+
+                unowned var location_obj = obj.get_object_member ("location");
+                if (location_obj != null) {
+                    debug (
+                        "Getting alerts for %s, %s, %s",
+                        location_obj.get_string_member ("name"),
+                        location_obj.get_string_member ("region"),
+                        location_obj.get_string_member ("country")
+                    );
+                }
+
+                unowned var alerts = obj.get_object_member ("alerts");
+                if (alerts == null) {
+                    warning ("No alerts object found!");
+                    return;
+                }
+
+                unowned var array = alerts.get_array_member ("alert");
+                if (array == null) {
+                    warning ("No alerts array found!");
+                    return;
+                }
+
+                unowned var app = GLib.Application.get_default ();
+                array.foreach_element ((array, index, element_node) => {
+                    unowned var alert_obj = element_node.get_object ();
+                    if (alert_obj == null) {
+                        warning ("No alert object found!");
+                        return;
+                    }
+
+                    var start_time = new DateTime.from_iso8601 (alert_obj.get_string_member ("effective"), null);
+
+                    var notification = new Notification (
+                        "%s starting %s on %s".printf (
+                            alert_obj.get_string_member ("event"),
+                            start_time.format (Granite.DateTime.get_default_time_format ()),
+                            start_time.format (Granite.DateTime.get_default_date_format ())
+                        )
+                    );
+                    notification.set_icon (new ThemedIcon ("dialog-error"));
+                    notification.set_body (alert_obj.get_string_member ("desc"));
+
+                    app.send_notification (alert_obj.get_string_member ("headline"), notification);
+                });
+            } catch (Error e) {
+                warning ("Failed to parse response as json: %s", e.message);
+            }
+        } catch (Error e) {
+            critical  ("Failed to send soup message: %s", e.message);
+        }
+    }
+}

--- a/src/meson.build
+++ b/src/meson.build
@@ -7,6 +7,7 @@ sources = files(
     'Backends/MouseSettings.vala',
     'Backends/NightLightSettings.vala',
     'Backends/PrefersColorSchemeSettings.vala',
+    'Backends/WeatherAlerts.vala',
     'Utils/SunriseSunsetCalculator.vala',
 )
 
@@ -19,8 +20,10 @@ executable(
         gio_dep,
         glib_dep,
         granite_dep,
+        json_dep,
         libgeoclue_dep,
         m_dep,
+        soup_dep
     ],
     install: true,
 )


### PR DESCRIPTION
Partly fixes #29 

Alerts the user about weather alerts found for their region. Should work (or at least it's advertised to work) worldwide and polls hourly. Uses the free API `api.weatherapi.com` ([https://www.weatherapi.com/](https://www.weatherapi.com/)). 
I have to admit that I'm not really familiar with accessing web API's like this so if I did something wrong I'd be happy to know.
For now to do some testing I used the aforementioned api because it's easy to use, free (at least for a million calls per month which might be limitting and we probably should mention them somewehere) and [allows pretty much any use even with the free plan](https://www.weatherapi.com/pricing.aspx) (no legal expert here though :)). I hardcoded an api token that's associated with a free account i created there (I know probably not very smart :)). I'm really no expert in this so if there are better apis or if there are other problems (maybe a million calls per month is not enough because with a every day use of  5 hour it ends up at around 6000 users) because of this please tell me and also it should be pretty easy to switch as long as it's an json api. 

Also the UX side probably could need some improvements especially some clearer phrasing or better icons. Maybe we should even add a default action that opens another window with a detailed description or opens a website etc.)