### PR TITLE
Implement system updates

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Install Dependencies
       run: |
         apt update
-        apt install -y libaccountsservice-dev libdbus-1-dev libgranite-dev libgeoclue-2-dev libfwupd-dev meson valac
+        apt install -y libaccountsservice-dev libdbus-1-dev libgranite-dev libgeoclue-2-dev libfwupd-dev libpackagekit-glib2-dev meson valac
     - name: Build
       env:
         DESTDIR: out

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ You'll need the following dependencies:
 * libfwupd-dev
 * libgeoclue-2-dev
 * libgranite-dev
+* libpackagekit-glib2-deb
 * meson
 * valac
 

--- a/data/io.elementary.settings-daemon.gschema.xml
+++ b/data/io.elementary.settings-daemon.gschema.xml
@@ -72,6 +72,11 @@
   </schema>
 
   <schema path="/io/elementary/settings-daemon/system-updates/" id="io.elementary.settings-daemon.system-updates">
+    <key type="x" name="last-refresh-time">
+      <default>0</default>
+      <summary>When updates were last refreshed</summary>
+      <description>When the cache was last refreshed and checked for updates in unix utc.</description>
+    </key>
     <key type="x" name="refresh-interval">
       <default>86400</default>
       <summary>How often to check for updates</summary>

--- a/data/io.elementary.settings-daemon.gschema.xml
+++ b/data/io.elementary.settings-daemon.gschema.xml
@@ -70,4 +70,12 @@
       <description>The day for calendars to use as the first day of the week</description>
      </key>
   </schema>
+
+  <schema path="/io/elementary/settings-daemon/system-updates/" id="io.elementary.settings-daemon.system-updates">
+    <key type="x" name="refresh-interval">
+      <default>86400</default>
+      <summary>How often to check for updates</summary>
+      <description>How often to check for updates in seconds.</description>
+    </key>
+  </schema>
 </schemalist>

--- a/data/io.elementary.settings-daemon.gschema.xml
+++ b/data/io.elementary.settings-daemon.gschema.xml
@@ -71,7 +71,7 @@
      </key>
   </schema>
 
-  <schema path="/io/elementary/settings-daemon/system-updates/" id="io.elementary.settings-daemon.system-updates">
+  <schema path="/io/elementary/settings-daemon/system-update/" id="io.elementary.settings-daemon.system-update">
     <key type="x" name="last-refresh-time">
       <default>0</default>
       <summary>When updates were last refreshed</summary>

--- a/meson.build
+++ b/meson.build
@@ -9,6 +9,7 @@ fwupd_dep = dependency('fwupd')
 gio_dep = dependency ('gio-2.0')
 glib_dep = dependency('glib-2.0')
 granite_dep = dependency('granite', version: '>= 5.3.0')
+pk_dep = dependency('packagekit-glib2')
 i18n = import('i18n')
 gettext_name = meson.project_name()
 

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -5,8 +5,8 @@
 
 public sealed class SettingsDaemon.Application : Gtk.Application {
     public const string ACTION_PREFIX = "app.";
-    public const string SHOW_UPDATES_ACTION = "show-udpates";
-    public const string SHOW_UPDATES_ERROR_ACTION = "show-udpates-error";
+    public const string SHOW_UPDATES_ACTION = "show-updates";
+    public const string SHOW_UPDATES_ERROR_ACTION = "show-updates-error";
 
     private AccountsService accounts_service;
     private Pantheon.AccountsService pantheon_service;

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -6,7 +6,6 @@
 public sealed class SettingsDaemon.Application : Gtk.Application {
     public const string ACTION_PREFIX = "app.";
     public const string SHOW_UPDATES_ACTION = "show-updates";
-    public const string SHOW_UPDATES_ERROR_ACTION = "show-updates-error";
 
     private AccountsService accounts_service;
     private Pantheon.AccountsService pantheon_service;
@@ -20,8 +19,6 @@ public sealed class SettingsDaemon.Application : Gtk.Application {
     private Backends.PrefersColorSchemeSettings prefers_color_scheme_settings;
 
     private Backends.Housekeeping housekeeping;
-
-    private Backends.SystemUpdate system_update;
 
     private const string FDO_ACCOUNTS_NAME = "org.freedesktop.Accounts";
     private const string FDO_ACCOUNTS_PATH = "/org/freedesktop/Accounts";
@@ -73,10 +70,6 @@ public sealed class SettingsDaemon.Application : Gtk.Application {
         });
         add_action (show_updates_action);
 
-        var show_updates_error_action = new GLib.SimpleAction (SHOW_UPDATES_ERROR_ACTION, null);
-        show_updates_error_action.activate.connect (system_update.show_error_details);
-        add_action (show_updates_error_action);
-
         setup_accounts_services.begin ();
         hold ();
     }
@@ -84,8 +77,7 @@ public sealed class SettingsDaemon.Application : Gtk.Application {
     protected override bool dbus_register (DBusConnection connection, string object_path) throws Error {
         base.dbus_register (connection, object_path);
 
-        system_update = new Backends.SystemUpdate ();
-        connection.register_object (object_path, system_update);
+        connection.register_object (object_path, new Backends.SystemUpdate ());
 
         return true;
     }

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -65,8 +65,7 @@ public sealed class SettingsDaemon.Application : Gtk.Application {
 
         var show_updates_action = new GLib.SimpleAction (SHOW_UPDATES_ACTION, null);
         show_updates_action.activate.connect (() => {
-            //TODO: settings uri for updates?
-            message ("SHOW UPDATES");
+            GLib.AppInfo.launch_default_for_uri_async.begin ("settings://about/os", null);
         });
         add_action (show_updates_action);
 

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -64,6 +64,14 @@ public sealed class SettingsDaemon.Application : Gtk.Application {
         hold ();
     }
 
+    protected override bool dbus_register (DBusConnection connection, string object_path) throws Error {
+        base.dbus_register (connection, object_path);
+
+        connection.register_object (object_path, new Backends.SystemUpdate ());
+
+        return true;
+    }
+
     private async void setup_accounts_services () {
         unowned GLib.DBusConnection connection;
         string path;

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -6,6 +6,7 @@
 public sealed class SettingsDaemon.Application : Gtk.Application {
     public const string ACTION_PREFIX = "app.";
     public const string SHOW_UPDATES_ACTION = "show-udpates";
+    public const string SHOW_UPDATES_ERROR_ACTION = "show-udpates-error";
 
     private AccountsService accounts_service;
     private Pantheon.AccountsService pantheon_service;
@@ -19,6 +20,8 @@ public sealed class SettingsDaemon.Application : Gtk.Application {
     private Backends.PrefersColorSchemeSettings prefers_color_scheme_settings;
 
     private Backends.Housekeeping housekeeping;
+
+    private Backends.SystemUpdate system_update;
 
     private const string FDO_ACCOUNTS_NAME = "org.freedesktop.Accounts";
     private const string FDO_ACCOUNTS_PATH = "/org/freedesktop/Accounts";
@@ -69,6 +72,10 @@ public sealed class SettingsDaemon.Application : Gtk.Application {
         });
         add_action (show_updates_action);
 
+        var show_updates_error_action = new GLib.SimpleAction (SHOW_UPDATES_ERROR_ACTION, null);
+        show_updates_error_action.activate.connect (system_update.show_error_details);
+        add_action (show_updates_error_action);
+
         setup_accounts_services.begin ();
         hold ();
     }
@@ -76,7 +83,8 @@ public sealed class SettingsDaemon.Application : Gtk.Application {
     protected override bool dbus_register (DBusConnection connection, string object_path) throws Error {
         base.dbus_register (connection, object_path);
 
-        connection.register_object (object_path, new Backends.SystemUpdate ());
+        system_update = new Backends.SystemUpdate ();
+        connection.register_object (object_path, system_update);
 
         return true;
     }

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -68,6 +68,7 @@ public sealed class SettingsDaemon.Application : Gtk.Application {
 
         var show_updates_action = new GLib.SimpleAction (SHOW_UPDATES_ACTION, null);
         show_updates_action.activate.connect (() => {
+            //TODO: settings uri for updates?
             message ("SHOW UPDATES");
         });
         add_action (show_updates_action);

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -4,6 +4,9 @@
  */
 
 public sealed class SettingsDaemon.Application : Gtk.Application {
+    public const string ACTION_PREFIX = "app.";
+    public const string SHOW_UPDATES_ACTION = "show-udpates";
+
     private AccountsService accounts_service;
     private Pantheon.AccountsService pantheon_service;
     private DisplayManager.AccountsService display_manager_service;
@@ -59,6 +62,12 @@ public sealed class SettingsDaemon.Application : Gtk.Application {
         var show_firmware_updates_action = new GLib.SimpleAction ("show-firmware-updates", null);
         show_firmware_updates_action.activate.connect (show_firmware_updates);
         add_action (show_firmware_updates_action);
+
+        var show_updates_action = new GLib.SimpleAction (SHOW_UPDATES_ACTION, null);
+        show_updates_action.activate.connect (() => {
+            message ("SHOW UPDATES");
+        });
+        add_action (show_updates_action);
 
         setup_accounts_services.begin ();
         hold ();

--- a/src/Backends/SystemUpdate.vala
+++ b/src/Backends/SystemUpdate.vala
@@ -28,11 +28,7 @@ public class SettingsDaemon.Backends.SystemUpdate : Object {
 
     public signal void state_changed ();
 
-    private static Settings settings;
-
-    static construct {
-        settings = new GLib.Settings ("io.elementary.settings-daemon.system-updates");
-    }
+    private static Settings settings = new GLib.Settings ("io.elementary.settings-daemon.system-updates");
 
     private CurrentState current_state;
     private UpdateDetails update_details;

--- a/src/Backends/SystemUpdate.vala
+++ b/src/Backends/SystemUpdate.vala
@@ -92,7 +92,7 @@ public class SettingsDaemon.Backends.SystemUpdate : Object {
 
             update_details = {
                 package_names,
-                0
+                0 //FIXME: Is there a way to get update size from PackageKit
             };
 
             var notification = new Notification (_("Update Available"));
@@ -141,7 +141,7 @@ public class SettingsDaemon.Backends.SystemUpdate : Object {
 
             last_error = e;
 
-            //This will also flush any already downloaded updates and disable the offline trigger
+            //This will also flush any already downloaded updates and disable the offline trigger (I think)
             check_for_updates.begin (true);
         }
     }

--- a/src/Backends/SystemUpdate.vala
+++ b/src/Backends/SystemUpdate.vala
@@ -26,6 +26,8 @@ public class SettingsDaemon.Backends.SystemUpdate : Object {
         int size;
     }
 
+    private const string NOTIFICATION_ID = "system-update";
+
     public signal void state_changed ();
 
     private static Settings settings = new GLib.Settings ("io.elementary.settings-daemon.system-updates");
@@ -107,12 +109,12 @@ public class SettingsDaemon.Backends.SystemUpdate : Object {
             };
 
             if (notify) {
-                var notification = new Notification (_("Update Available"));
+                var notification = new Notification (_("Update available"));
                 notification.set_body (_("A system update is available"));
                 notification.set_icon (new ThemedIcon ("software-update-available"));
                 notification.set_default_action (Application.ACTION_PREFIX + Application.SHOW_UPDATES_ACTION);
 
-                GLib.Application.get_default ().send_notification (null, notification);
+                GLib.Application.get_default ().send_notification (NOTIFICATION_ID, notification);
             }
 
             update_state (AVAILABLE);
@@ -142,12 +144,12 @@ public class SettingsDaemon.Backends.SystemUpdate : Object {
 
             Pk.offline_trigger (REBOOT);
 
-            var notification = new Notification (_("Restart Required"));
+            var notification = new Notification (_("Restart required"));
             notification.set_body (_("Please restart your system to finalize updates"));
             notification.set_icon (new ThemedIcon ("system-reboot"));
             notification.set_default_action (Application.ACTION_PREFIX + Application.SHOW_UPDATES_ACTION);
 
-            GLib.Application.get_default ().send_notification (null, notification);
+            GLib.Application.get_default ().send_notification (NOTIFICATION_ID, notification);
 
             update_state (RESTART_REQUIRED);
         } catch (Error e) {
@@ -165,12 +167,12 @@ public class SettingsDaemon.Backends.SystemUpdate : Object {
     }
 
     private void send_error (string message) {
-        var notification = new Notification (_("Update failed"));
-        notification.set_body (_("An Error occured while trying to update your system"));
+        var notification = new Notification (_("System updates couldn't be installed"));
+        notification.set_body (_("An error occured while trying to update your system"));
         notification.set_icon (new ThemedIcon ("dialog-error"));
         notification.set_default_action (Application.ACTION_PREFIX + Application.SHOW_UPDATES_ACTION);
 
-        GLib.Application.get_default ().send_notification (null, notification);
+        GLib.Application.get_default ().send_notification (NOTIFICATION_ID, notification);
 
         update_state (ERROR, message);
     }

--- a/src/Backends/SystemUpdate.vala
+++ b/src/Backends/SystemUpdate.vala
@@ -20,8 +20,8 @@ public class SettingsDaemon.Backends.SystemUpdate : Object {
 
     public signal void state_changed ();
 
-    public CurrentState current_state { get; private set; }
-    public UpdateDetails update_details { get; private set; default = UpdateDetails (); }
+    private CurrentState current_state;
+    private UpdateDetails update_details;
 
     private Pk.Task task;
     private Pk.PackageSack? available_updates = null;
@@ -33,6 +33,11 @@ public class SettingsDaemon.Backends.SystemUpdate : Object {
             0
         };
 
+        update_details = {
+            {},
+            0
+        };
+
         task = new Pk.Task () {
             only_download = true
         };
@@ -40,7 +45,7 @@ public class SettingsDaemon.Backends.SystemUpdate : Object {
         check_for_updates.begin ();
     }
 
-    private async void check_for_updates (bool force = false) {
+    public async void check_for_updates (bool force = false) {
         if (current_state.state != UP_TO_DATE && !force) {
             return;
         }
@@ -133,5 +138,13 @@ public class SettingsDaemon.Backends.SystemUpdate : Object {
         };
 
         state_changed ();
+    }
+
+    public async CurrentState get_current_state () throws DBusError, IOError {
+        return current_state;
+    }
+
+    public async UpdateDetails get_update_details () throws DBusError, IOError {
+        return update_details;
     }
 }

--- a/src/Backends/SystemUpdate.vala
+++ b/src/Backends/SystemUpdate.vala
@@ -30,7 +30,7 @@ public class SettingsDaemon.Backends.SystemUpdate : Object {
 
     public signal void state_changed ();
 
-    private static Settings settings = new GLib.Settings ("io.elementary.settings-daemon.system-updates");
+    private static Settings settings = new GLib.Settings ("io.elementary.settings-daemon.system-update");
 
     private CurrentState current_state;
     private UpdateDetails update_details;

--- a/src/Backends/SystemUpdate.vala
+++ b/src/Backends/SystemUpdate.vala
@@ -1,3 +1,10 @@
+/*
+ * Copyright 2023 elementary, Inc. (https://elementary.io)
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * Authored by: Leonhard Kargl <leo.kargl@proton.me>
+ */
+
 [DBus (name="io.elementary.settings_daemon.SystemUpdate")]
 public class SettingsDaemon.Backends.SystemUpdate : Object {
     public enum State {
@@ -10,7 +17,7 @@ public class SettingsDaemon.Backends.SystemUpdate : Object {
 
     public struct CurrentState {
         State state;
-        int progress;
+        string status;
     }
 
     public struct UpdateDetails {
@@ -30,7 +37,7 @@ public class SettingsDaemon.Backends.SystemUpdate : Object {
     construct {
         current_state = {
             UP_TO_DATE,
-            0
+            ""
         };
 
         update_details = {
@@ -53,13 +60,13 @@ public class SettingsDaemon.Backends.SystemUpdate : Object {
         update_state (CHECKING);
 
         try {
-            yield task.refresh_cache_async (false, null, () => {});
+            yield task.refresh_cache_async (false, null, progress_callback);
         } catch (Error e) {
             warning ("Failed to refresh cache: %s", e.message);
         }
 
         try {
-            available_updates = (yield task.get_updates_async (Pk.Filter.NONE, null, () => {})).get_package_sack ();
+            available_updates = (yield task.get_updates_async (Pk.Filter.NONE, null, progress_callback)).get_package_sack ();
 
             if (available_updates == null || available_updates.get_size () == 0) {
                 update_state (UP_TO_DATE);
@@ -99,18 +106,14 @@ public class SettingsDaemon.Backends.SystemUpdate : Object {
             return;
         }
 
-        update_state (DOWNLOADING, 0);
+        update_state (DOWNLOADING);
 
         try {
-            var result = yield task.update_packages_async (available_updates.get_ids (), null, (progress, progress_type) => {
-                if (progress_type == PERCENTAGE) {
-                    update_state (DOWNLOADING, progress.percentage);
-                }
-            });
+            var result = yield task.update_packages_async (available_updates.get_ids (), null, progress_callback);
 
             Pk.offline_trigger (REBOOT);
 
-            update_state (RESTART_REQUIRED, 0);
+            update_state (RESTART_REQUIRED);
         } catch (Error e) {
             critical ("Failed to download available updates: %s", e.message);
 
@@ -131,13 +134,94 @@ public class SettingsDaemon.Backends.SystemUpdate : Object {
         }
     }
 
-    private void update_state (State state, int progress = 0) {
+    private void progress_callback (Pk.Progress progress, Pk.ProgressType progress_type) {
+        update_state (current_state.state, status_to_title (progress.status));
+    }
+
+    private void update_state (State state, string message = "") {
         current_state = {
             state,
-            progress
+            message
         };
 
         state_changed ();
+    }
+
+    private unowned string status_to_title (Pk.Status status) {
+        // From https://github.com/elementary/appcenter/blob/master/src/Core/ChangeInformation.vala#L51
+        switch (status) {
+            case Pk.Status.SETUP:
+                return _("Starting");
+            case Pk.Status.WAIT:
+                return _("Waiting");
+            case Pk.Status.RUNNING:
+                return _("Running");
+            case Pk.Status.QUERY:
+                return _("Querying");
+            case Pk.Status.INFO:
+                return _("Getting information");
+            case Pk.Status.REMOVE:
+                return _("Removing packages");
+            case Pk.Status.DOWNLOAD:
+                return _("Downloading");
+            case Pk.Status.REFRESH_CACHE:
+                return _("Refreshing software list");
+            case Pk.Status.UPDATE:
+                return _("Installing updates");
+            case Pk.Status.CLEANUP:
+                return _("Cleaning up packages");
+            case Pk.Status.OBSOLETE:
+                return _("Obsoleting packages");
+            case Pk.Status.DEP_RESOLVE:
+                return _("Resolving dependencies");
+            case Pk.Status.SIG_CHECK:
+                return _("Checking signatures");
+            case Pk.Status.TEST_COMMIT:
+                return _("Testing changes");
+            case Pk.Status.COMMIT:
+                return _("Committing changes");
+            case Pk.Status.REQUEST:
+                return _("Requesting data");
+            case Pk.Status.FINISHED:
+                return _("Finished");
+            case Pk.Status.CANCEL:
+                return _("Cancelling");
+            case Pk.Status.DOWNLOAD_REPOSITORY:
+                return _("Downloading repository information");
+            case Pk.Status.DOWNLOAD_PACKAGELIST:
+                return _("Downloading list of packages");
+            case Pk.Status.DOWNLOAD_FILELIST:
+                return _("Downloading file lists");
+            case Pk.Status.DOWNLOAD_CHANGELOG:
+                return _("Downloading lists of changes");
+            case Pk.Status.DOWNLOAD_GROUP:
+                return _("Downloading groups");
+            case Pk.Status.DOWNLOAD_UPDATEINFO:
+                return _("Downloading update information");
+            case Pk.Status.REPACKAGING:
+                return _("Repackaging files");
+            case Pk.Status.LOADING_CACHE:
+                return _("Loading cache");
+            case Pk.Status.SCAN_APPLICATIONS:
+                return _("Scanning applications");
+            case Pk.Status.GENERATE_PACKAGE_LIST:
+                return _("Generating package lists");
+            case Pk.Status.WAITING_FOR_LOCK:
+                return _("Waiting for package manager lock");
+            case Pk.Status.WAITING_FOR_AUTH:
+                return _("Waiting for authentication");
+            case Pk.Status.SCAN_PROCESS_LIST:
+                return _("Updating running applications");
+            case Pk.Status.CHECK_EXECUTABLE_FILES:
+                return _("Checking applications in use");
+            case Pk.Status.CHECK_LIBRARIES:
+                return _("Checking libraries in use");
+            case Pk.Status.COPY_FILES:
+                return _("Copying files");
+            case Pk.Status.INSTALL:
+            default:
+                return _("Installing");
+        }
     }
 
     public async CurrentState get_current_state () throws DBusError, IOError {

--- a/src/Backends/SystemUpdate.vala
+++ b/src/Backends/SystemUpdate.vala
@@ -95,11 +95,8 @@ public class SettingsDaemon.Backends.SystemUpdate : Object {
                 0
             };
 
-            string title = ngettext ("Update Available", "Updates Available", available_updates.get_size ());
-            string body = ngettext ("%u update is available for your system", "%u updates are available for your system", available_updates.get_size ()).printf (available_updates.get_size ());
-
-            var notification = new Notification (title);
-            notification.set_body (body);
+            var notification = new Notification (_("Update Available"));
+            notification.set_body (_("A system update is available"));
             notification.set_icon (new ThemedIcon ("software-update-available"));
             notification.set_default_action (Application.ACTION_PREFIX + Application.SHOW_UPDATES_ACTION);
 
@@ -124,12 +121,10 @@ public class SettingsDaemon.Backends.SystemUpdate : Object {
 
             Pk.offline_trigger (REBOOT);
 
-            string title = _("Restart Required");
-            string body = _("Please restart your system to finalize updates");
-
-            var notification = new Notification (title);
-            notification.set_body (body);
+            var notification = new Notification (_("Restart Required"));
+            notification.set_body (_("Please restart your system to finalize updates"));
             notification.set_icon (new ThemedIcon ("system-reboot"));
+            notification.set_default_action (Application.ACTION_PREFIX + Application.SHOW_UPDATES_ACTION);
 
             GLib.Application.get_default ().send_notification (null, notification);
 
@@ -137,11 +132,8 @@ public class SettingsDaemon.Backends.SystemUpdate : Object {
         } catch (Error e) {
             critical ("Failed to download available updates: %s", e.message);
 
-            string title = _("Update failed");
-            string body = _("An Error occured while trying to update your system");
-
-            var notification = new Notification (title);
-            notification.set_body (body);
+            var notification = new Notification (_("Update failed"));
+            notification.set_body (_("An Error occured while trying to update your system"));
             notification.set_icon (new ThemedIcon ("dialog-error"));
             notification.set_default_action (Application.ACTION_PREFIX + Application.SHOW_UPDATES_ERROR_ACTION);
 

--- a/src/Backends/SystemUpdate.vala
+++ b/src/Backends/SystemUpdate.vala
@@ -82,6 +82,8 @@ public class SettingsDaemon.Backends.SystemUpdate : Object {
         try {
             available_updates = (yield task.get_updates_async (Pk.Filter.NONE, null, progress_callback)).get_package_sack ();
 
+            settings.set_int64 ("last-refresh-time", new DateTime.now_utc ().to_unix ());
+
             if (available_updates == null || available_updates.get_size () == 0) {
                 update_state (UP_TO_DATE);
                 return;

--- a/src/Backends/SystemUpdate/SystemUpdate.vala
+++ b/src/Backends/SystemUpdate/SystemUpdate.vala
@@ -1,0 +1,107 @@
+[DBus (name="io.elementary.settings_daemon.SystemUpdate")]
+public class SettingsDaemon.Backends.SystemUpdate : Object {
+    public enum State {
+        UP_TO_DATE,
+        CHECKING,
+        AVAILABLE,
+        DOWNLOADING,
+        RESTART_REQUIRED
+    }
+
+    public struct CurrentState {
+        State state;
+        int progress;
+    }
+
+    public struct UpdateDetails {
+        string[] packages;
+        int size;
+    }
+
+    public signal void state_changed ();
+
+    public CurrentState current_state { get; private set; }
+    public UpdateDetails update_details { get; private set; default = UpdateDetails (); }
+
+    private Pk.Task task;
+    private Pk.PackageSack? available_updates = null;
+
+    construct {
+        current_state = {
+            UP_TO_DATE,
+            0
+        };
+
+        task = new Pk.Task () {
+            only_download = true
+        };
+        check_for_updates.begin ();
+    }
+
+    private async void check_for_updates (bool force = false) {
+        if (current_state.state != UP_TO_DATE && !force) {
+            return;
+        }
+
+        update_state (CHECKING);
+
+        try {
+            available_updates = (yield task.get_updates_async (Pk.Filter.NONE, null, () => {})).get_package_sack ();
+
+            if (available_updates == null || available_updates.get_size () == 0) {
+                update_state (UP_TO_DATE);
+                return;
+            }
+
+            string[] package_names = {};
+
+            foreach (var package in available_updates.get_array ()) {
+                package_names += package.get_name ();
+            }
+
+            update_details = {
+                package_names,
+                0
+            };
+
+            update_state (AVAILABLE);
+        } catch (Error e) {
+            warning ("Failed to get available updates: %s", e.message);
+            update_state (UP_TO_DATE);
+        }
+    }
+
+    public async void update () throws DBusError, IOError {
+        if (current_state.state != AVAILABLE) {
+            return;
+        }
+
+        update_state (DOWNLOADING, 0);
+
+        try {
+            var result = yield task.update_packages_async (available_updates.get_ids (), null, (progress, progress_type) => {
+                if (progress_type == PERCENTAGE) {
+                    update_state (DOWNLOADING, progress.percentage);
+                }
+            });
+
+            Pk.offline_trigger (REBOOT);
+
+            update_state (RESTART_REQUIRED, 0);
+        } catch (Error e) {
+            warning ("Failed to get available updates: %s", e.message);
+
+            //This will also flush any already downloaded updates and disable the offline trigger
+            check_for_updates.begin (true);
+        }
+    }
+
+    private void update_state (State state, int progress = 0) {
+        current_state = {
+            state,
+            progress
+        };
+
+        state_changed ();
+    }
+}

--- a/src/meson.build
+++ b/src/meson.build
@@ -7,6 +7,7 @@ sources = files(
     'Backends/MouseSettings.vala',
     'Backends/NightLightSettings.vala',
     'Backends/PrefersColorSchemeSettings.vala',
+    'Backends/SystemUpdate/SystemUpdate.vala',
     'Utils/SunriseSunsetCalculator.vala',
 )
 
@@ -21,6 +22,7 @@ executable(
         granite_dep,
         libgeoclue_dep,
         m_dep,
+        pk_dep
     ],
     install: true,
 )

--- a/src/meson.build
+++ b/src/meson.build
@@ -7,7 +7,7 @@ sources = files(
     'Backends/MouseSettings.vala',
     'Backends/NightLightSettings.vala',
     'Backends/PrefersColorSchemeSettings.vala',
-    'Backends/SystemUpdate/SystemUpdate.vala',
+    'Backends/SystemUpdate.vala',
     'Utils/SunriseSunsetCalculator.vala',
 )
 


### PR DESCRIPTION
Featurewise this should be pretty much on par with what appcenter currently does. In my testing it was very reliable and quite fast since it only has to deal with packagekit and not appstream and/or flatpak.

It will send notifications about updates, restart required and update failed.

This goes towards addressing elementary/appcenter#2107. Since we need packagekit for ubuntudrivers anyways I started with this (and because I know packagekit and don't know ubuntu drivers or the distro agnostic driver management mentioned there. The only thing I could find in this direction was an old solus project 🤷)