### PR TITLE
Add hidden option to toggle offline updates

### DIFF
--- a/data/io.elementary.settings-daemon.gschema.xml
+++ b/data/io.elementary.settings-daemon.gschema.xml
@@ -77,6 +77,11 @@
       <summary>Automatic updates</summary>
       <description>Whether to automatically download updates</description>
     </key>
+    <key type="b" name="offline-updates">
+      <default>true</default>
+      <summary>Offline updates</summary>
+      <description>Whether to install updates offline</description>
+    </key>
     <key type="x" name="last-refresh-time">
       <default>0</default>
       <summary>When updates were last refreshed</summary>

--- a/src/Backends/SystemUpdate.vala
+++ b/src/Backends/SystemUpdate.vala
@@ -52,9 +52,9 @@ public class SettingsDaemon.Backends.SystemUpdate : Object {
             {}
         };
 
-        task = new Pk.Task () {
-            only_download = true
-        };
+        task = new Pk.Task ();
+
+        settings.bind ("offline-updates", task, "only-download", GET);
 
         cancellable = new GLib.Cancellable ();
 
@@ -160,7 +160,7 @@ public class SettingsDaemon.Backends.SystemUpdate : Object {
         try {
             var results = yield task.update_packages_async (available_updates.get_ids (), cancellable, progress_callback);
 
-            if (results.get_exit_code () == CANCELLED) {
+            if (results.get_exit_code () == CANCELLED || settings.get_boolean ("offline-updates")) {
                 debug ("Updates were cancelled");
                 check_for_updates.begin (true, false);
                 return;

--- a/src/Backends/SystemUpdate.vala
+++ b/src/Backends/SystemUpdate.vala
@@ -160,7 +160,7 @@ public class SettingsDaemon.Backends.SystemUpdate : Object {
         try {
             var results = yield task.update_packages_async (available_updates.get_ids (), cancellable, progress_callback);
 
-            if (results.get_exit_code () == CANCELLED || settings.get_boolean ("offline-updates")) {
+            if (results.get_exit_code () == CANCELLED || !settings.get_boolean ("offline-updates")) {
                 debug ("Updates were cancelled");
                 check_for_updates.begin (true, false);
                 return;


### PR DESCRIPTION
Not sure whether this will be accepted but it adds a hidden setting to toggle offline updates, i.e. whether packagekits offline update mechanism is used and therefore a restart being required.
I think updates without restarting aren't the most dangerous thing and someone who manages to toggle this setting via dconf probably knows the risks.
My main reason for this is because I dual boot and have to spam keys during startup so every update forces me to sit in front of my pc for two minutes doing nothing and even though that's obviously not the worst thing ever I just cant be bothered anymore :)