### PR TITLE
meson: Don't run gtk-update-icon-cache

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -54,4 +54,7 @@ subdir('po')
 subdir('src')
 subdir('settings-portal')
 
-gnome.post_install(glib_compile_schemas: true, gtk_update_icon_cache: true, update_desktop_database: true)
+gnome.post_install(
+    glib_compile_schemas: true,
+    update_desktop_database: true
+)


### PR DESCRIPTION
We install nothing to `$datadir/icons/hicolor` right now.

- Same as https://github.com/elementary/files/pull/2294, which unbreaks NixOS build.