### PR TITLE
POTFILES: Add autostart.desktop

### DIFF
--- a/po/POTFILES
+++ b/po/POTFILES
@@ -1,3 +1,4 @@
+data/autostart.desktop
 data/settings-daemon.metainfo.xml.in
 src/Application.vala
 src/Backends/SystemUpdate.vala


### PR DESCRIPTION
So that we can translate the provider name in the notification indicator, which is currently shown as untranslated:

![screenshot](https://github.com/elementary/settings-daemon/assets/26003928/6f83eedb-d579-44b5-b73b-ad2ab3b48fd0)
