### PR TITLE
Localize autostart.desktop

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -1,7 +1,10 @@
-install_data(
-    'autostart.desktop',
-    install_dir: datadir / 'applications',
-    rename: meson.project_name() + '.desktop'
+i18n.merge_file(
+    input: 'autostart.desktop',
+    output: meson.project_name() + '.desktop',
+    po_dir: meson.project_source_root() / 'po',
+    type: 'desktop',
+    install: true,
+    install_dir: datadir / 'applications'
 )
 
 fs = import('fs')


### PR DESCRIPTION
#142 is not enough to fix the issue that the provider name in the notification indicator is not translated.

I confirmed it's now shown as translated with this change:

![screenshot](https://github.com/elementary/settings-daemon/assets/26003928/8495dc0c-2def-41f3-b1dc-131b62061785)
