### PR TITLE
UbuntuDrivers: Update notification copy

### DIFF
--- a/po/POTFILES
+++ b/po/POTFILES
@@ -2,3 +2,5 @@ data/autostart.desktop
 data/settings-daemon.metainfo.xml.in
 src/Application.vala
 src/Backends/SystemUpdate.vala
+src/Backends/UbuntuDrivers.vala
+src/Utils/PkUtils.vala

--- a/src/Backends/UbuntuDrivers.vala
+++ b/src/Backends/UbuntuDrivers.vala
@@ -166,9 +166,16 @@ public class SettingsDaemon.Backends.UbuntuDrivers : Object {
         update_state (AVAILABLE);
 
         if (notify) {
-            var notification = new Notification (_("Drivers available"));
+            var title = ngettext ("Driver Available", "Drivers Available", available_drivers.length);
+            var body = ngettext (
+                "%u driver is available for your hardware",
+                "%u drivers are available for your hardware",
+                available_drivers.length
+            );
+
+            var notification = new Notification (title);
             notification.set_default_action (Application.ACTION_PREFIX + Application.SHOW_UPDATES_ACTION);
-            notification.set_body (_("For your system are drivers available"));
+            notification.set_body (body.printf (available_drivers.length));
             notification.set_icon (new ThemedIcon ("software-update-available"));
 
             GLib.Application.get_default ().send_notification (NOTIFICATION_ID, notification);


### PR DESCRIPTION
Update the driver notification text to be consistent with updates notification (`Updates Available`).

Also update POTFILES while I'm here.