### PR TITLE
wayland: Fix autostart

### DIFF
--- a/data/autostart.desktop
+++ b/data/autostart.desktop
@@ -10,5 +10,5 @@ NoDisplay=true
 StartupNotify=true
 X-GNOME-AutoRestart=true
 X-GNOME-Autostart-Notify=true
-X-GNOME-Autostart-Phase=Initialization
+X-GNOME-Autostart-Phase=Panel
 OnlyShowIn=Pantheon


### PR DESCRIPTION
Fixes #148

Haven't tested but settings daemon is a GTK app so it will exit if it is launched without an available display, i.e. before the wm.