### PR TITLE
SystemUpdate: make sure we notify if network is metered

### DIFF
--- a/src/Backends/SystemUpdate.vala
+++ b/src/Backends/SystemUpdate.vala
@@ -124,7 +124,7 @@ public class SettingsDaemon.Backends.SystemUpdate : Object {
                 return;
             }
 
-            if (notify) {
+            if (notify || NetworkMonitor.get_default ().network_metered) {
                 var notification = new Notification (_("Update available"));
                 notification.set_default_action (Application.ACTION_PREFIX + Application.SHOW_UPDATES_ACTION);
 


### PR DESCRIPTION
We don't install updates automatically on a metered network even if auto updates is turned on so make sure we notify