### PR TITLE
build: Fix build with fwupd 2.0.0

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -17,6 +17,10 @@ pk_dep = dependency('packagekit-glib2')
 i18n = import('i18n')
 gettext_name = meson.project_name()
 
+if fwupd_dep.version().version_compare('>=2.0.0')
+    add_project_arguments('--define', 'HAS_FWUPD_2_0', language: 'vala')
+endif
+
 add_project_arguments(
     '-DGETTEXT_PACKAGE="@0@"'.format(gettext_name),
     language:'c'

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -137,7 +137,11 @@ public sealed class SettingsDaemon.Application : Gtk.Application {
             var devices = client.get_devices ();
 
             foreach (unowned var device in devices) {
+#if HAS_FWUPD_2_0
+                if (!device.has_flag (Fwupd.DeviceFlags.UPDATABLE)) {
+#else
                 if (!device.has_flag (Fwupd.DEVICE_FLAG_UPDATABLE)) {
+#endif
                     continue;
                 }
 


### PR DESCRIPTION
Based on https://gitlab.archlinux.org/archlinux/packaging/packages/pantheon-settings-daemon/-/commit/e1f48299fdc39d3825fa65cfbcce54678e34a823.

Fixes:

```
../src/Application.vala:140.39-140.65: error: The name `DEVICE_FLAG_UPDATABLE' does not exist in the context of `Fwupd' (fwupd)
  140 |                 if (!device.has_flag (Fwupd.DEVICE_FLAG_UPDATABLE)) {
      |                                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~'
```