### PR TITLE
SystemUpdate: Share last refresh time via DBus

### DIFF
--- a/src/Backends/SystemUpdate.vala
+++ b/src/Backends/SystemUpdate.vala
@@ -21,11 +21,11 @@ public class SettingsDaemon.Backends.SystemUpdate : Object {
 
     private PkUtils.CurrentState current_state;
     private UpdateDetails update_details;
-    private int64 last_refresh_time;
 
     private Pk.Task task;
     private Pk.PackageSack? available_updates = null;
     private GLib.Cancellable cancellable;
+    private int64 last_refresh_time;
 
     construct {
         current_state = {
@@ -45,9 +45,9 @@ public class SettingsDaemon.Backends.SystemUpdate : Object {
             only_download = true
         };
 
-        last_refresh_time = settings.get_int64 ("last-refresh-time");
-
         cancellable = new GLib.Cancellable ();
+
+        last_refresh_time = settings.get_int64 ("last-refresh-time");
 
         try {
             var last_offline_results = Pk.offline_get_results ();

--- a/src/Backends/SystemUpdate.vala
+++ b/src/Backends/SystemUpdate.vala
@@ -21,6 +21,7 @@ public class SettingsDaemon.Backends.SystemUpdate : Object {
 
     private PkUtils.CurrentState current_state;
     private UpdateDetails update_details;
+    private int64 last_refresh_time;
 
     private Pk.Task task;
     private Pk.PackageSack? available_updates = null;
@@ -43,6 +44,8 @@ public class SettingsDaemon.Backends.SystemUpdate : Object {
         task = new Pk.Task () {
             only_download = true
         };
+
+        last_refresh_time = settings.get_int64 ("last-refresh-time");
 
         cancellable = new GLib.Cancellable ();
 
@@ -97,7 +100,8 @@ public class SettingsDaemon.Backends.SystemUpdate : Object {
         try {
             available_updates = (yield task.get_updates_async (Pk.Filter.NONE, null, progress_callback)).get_package_sack ();
 
-            settings.set_int64 ("last-refresh-time", new DateTime.now_utc ().to_unix ());
+            last_refresh_time = new DateTime.now_utc ().to_unix ();
+            settings.set_int64 ("last-refresh-time", last_refresh_time);
 
             if (available_updates == null || available_updates.get_size () == 0) {
                 update_state (UP_TO_DATE);
@@ -232,5 +236,9 @@ public class SettingsDaemon.Backends.SystemUpdate : Object {
 
     public async UpdateDetails get_update_details () throws DBusError, IOError {
         return update_details;
+    }
+
+    public async int64 get_last_refresh_time () throws DBusError, IOError {
+        return last_refresh_time;
     }
 }

--- a/src/Backends/SystemUpdate.vala
+++ b/src/Backends/SystemUpdate.vala
@@ -25,7 +25,6 @@ public class SettingsDaemon.Backends.SystemUpdate : Object {
     private Pk.Task task;
     private Pk.PackageSack? available_updates = null;
     private GLib.Cancellable cancellable;
-    private int64 last_refresh_time;
 
     construct {
         current_state = {
@@ -46,8 +45,6 @@ public class SettingsDaemon.Backends.SystemUpdate : Object {
         };
 
         cancellable = new GLib.Cancellable ();
-
-        last_refresh_time = settings.get_int64 ("last-refresh-time");
 
         try {
             var last_offline_results = Pk.offline_get_results ();
@@ -100,7 +97,7 @@ public class SettingsDaemon.Backends.SystemUpdate : Object {
         try {
             available_updates = (yield task.get_updates_async (Pk.Filter.NONE, null, progress_callback)).get_package_sack ();
 
-            set_last_refresh_time (new DateTime.now_utc ().to_unix ());
+            settings.set_int64 ("last-refresh-time", new DateTime.now_utc ().to_unix ());
 
             if (available_updates == null || available_updates.get_size () == 0) {
                 update_state (UP_TO_DATE);
@@ -237,12 +234,7 @@ public class SettingsDaemon.Backends.SystemUpdate : Object {
         return update_details;
     }
 
-    private void set_last_refresh_time (int64 time) {
-        last_refresh_time = time;
-        settings.set_int64 ("last-refresh-time", last_refresh_time);
-    }
-
     public async int64 get_last_refresh_time () throws DBusError, IOError {
-        return last_refresh_time;
+        return settings.get_int64 ("last-refresh-time");
     }
 }

--- a/src/Backends/SystemUpdate.vala
+++ b/src/Backends/SystemUpdate.vala
@@ -100,8 +100,7 @@ public class SettingsDaemon.Backends.SystemUpdate : Object {
         try {
             available_updates = (yield task.get_updates_async (Pk.Filter.NONE, null, progress_callback)).get_package_sack ();
 
-            last_refresh_time = new DateTime.now_utc ().to_unix ();
-            settings.set_int64 ("last-refresh-time", last_refresh_time);
+            set_last_refresh_time (new DateTime.now_utc ().to_unix ());
 
             if (available_updates == null || available_updates.get_size () == 0) {
                 update_state (UP_TO_DATE);
@@ -236,6 +235,11 @@ public class SettingsDaemon.Backends.SystemUpdate : Object {
 
     public async UpdateDetails get_update_details () throws DBusError, IOError {
         return update_details;
+    }
+
+    private void set_last_refresh_time (int64 time) {
+        last_refresh_time = time;
+        settings.set_int64 ("last-refresh-time", last_refresh_time);
     }
 
     public async int64 get_last_refresh_time () throws DBusError, IOError {


### PR DESCRIPTION
Fixes elementary/switchboard-plug-about#342

I think this is a racing issue. The plug possibly reads from `last-refresh-time` before Settings Daemon writes to it.

This issue wouldn't happen by making the plug inquire last refresh time from Settings Daemon instead of from GSettings, because Settings Daemon runs in a single thread and the following things happen in order:

- Settings Daemon updates the value of `last_refresh_time` at [SystemUpdate.vala#L103](https://github.com/elementary/settings-daemon/blob/15bbe9602b560c1f00a4ec8d64633d2964c3a815/src/Backends/SystemUpdate.vala#L103)
- When there are no updates, Settings Daemon executes `update_state (UP_TO_DATE);` at [SystemUpdate.vala#L107](https://github.com/elementary/settings-daemon/blob/15bbe9602b560c1f00a4ec8d64633d2964c3a815/src/Backends/SystemUpdate.vala#L107), which emits `state_changed ()` signal at [SystemUpdate.vala#L230](https://github.com/elementary/settings-daemon/blob/15bbe9602b560c1f00a4ec8d64633d2964c3a815/src/Backends/SystemUpdate.vala#L230). Then Settings Daemon returns `check_for_updates ()` method
- System Plug runs the callback of the `state_changed ()` signal, `update_state ()` method, at [OperatingSystemView.vala#L389](https://github.com/elementary/switchboard-plug-about/blob/13d420183563e6e4a75c0f2c0b27ce56004fce6c/src/Views/OperatingSystemView.vala#L389)
- System Plug calls `update_proxy.get_last_refresh_time ()` at [OperatingSystemView.vala#L512](https://github.com/elementary/switchboard-plug-about/blob/13d420183563e6e4a75c0f2c0b27ce56004fce6c/src/Views/OperatingSystemView.vala#L512)
- Settings Daemon runs `get_last_refresh_time ()` at [SystemUpdate.vala#L241](https://github.com/elementary/settings-daemon/blob/15bbe9602b560c1f00a4ec8d64633d2964c3a815/src/Backends/SystemUpdate.vala#L241) via DBus call from System Plug
