### PR TITLE
meson: Fix use of string value for a boolean option

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,4 +1,4 @@
 option('busctlpath', type: 'string', value: '', description: 'custom path to busctl executable')
-option('ubuntu_drivers', type: 'boolean', value: 'true', description: 'whether to enable ubuntu drivers integration')
+option('ubuntu_drivers', type: 'boolean', value: true, description: 'whether to enable ubuntu drivers integration')
 option('systemdsystemunitdir', type: 'string', value: '', description: 'custom directory for systemd system units, or \'no\' to disable')
 option('systemduserunitdir', type: 'string', value: '', description: 'custom directory for systemd user units, or \'no\' to disable')


### PR DESCRIPTION
This fixes the following warning on build:

    * 1.1.0: {'"boolean option" keyword argument "value" of type str'}