### PR TITLE
PrefersColorSchemeSettings: add gsetting 

### DIFF
--- a/data/io.elementary.settings-daemon.gschema.xml
+++ b/data/io.elementary.settings-daemon.gschema.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schemalist>
+  <enum id="ColorScheme">
+    <value nick='no-preference' value='0'/>
+    <value nick='prefer-dark' value='1'/>
+    <value nick='prefer-light' value='2'/>
+  </enum>
+
   <enum id="PreferDarkScheduleType">
     <value nick='disabled' value='0'/>
     <value nick='sunset-to-sunrise' value='1'/>
@@ -7,6 +13,11 @@
   </enum>
 
   <schema path="/io/elementary/settings-daemon/prefers-color-scheme/" id="io.elementary.settings-daemon.prefers-color-scheme">
+    <key enum="ColorScheme" name="color-scheme">
+      <default>'no-preference'</default>
+      <summary>Color Scheme</summary>
+      <description>The preferred color scheme for the user interface. Valid values are “no-preference”, “prefer-dark”, “prefer-light”.</description>
+    </key>
     <key enum="PreferDarkScheduleType" name="prefer-dark-schedule">
       <default>'disabled'</default>
       <summary>Algorithm for prefer dark schedule</summary>

--- a/data/io.elementary.settings-daemon.gschema.xml
+++ b/data/io.elementary.settings-daemon.gschema.xml
@@ -33,6 +33,11 @@
       <summary>The stop time</summary>
       <description></description>
     </key>
+    <key type="b" name="prefer-dark-schedule-snoozed">
+      <default>false</default>
+      <summary>Snooze Dark Schedule</summary>
+      <description>True if color scheme was changed during the dark mode schedule. Does nothing if set directly.</description>
+    </key>
     <key type="(dd)" name="last-coordinates">
       <default>(91,181)</default>
       <summary>The last detected position</summary>


### PR DESCRIPTION
Can be rebase merged

Fixes #14 
Fixes #84

Needed to eventually fix #162 

- Adds a new gsetting to set dark mode via settings daemon. This will cut down on duplicate code in Quick Settings and System Settings to set dark mode. Make sure we always handle setting things needed for Mutter, syncing to accountsservice, etc.
- Adds a new bool for snoozed state and set it automatically. This is so you can manually toggle dark mode on and off without canceling your schedule or having the schedule change the setting right back. Snooze will be disabled next time the schedule and color scheme are in sync or the schedule is disabled.