### PR TITLE
Don't use AccountService for color scheme

### DIFF
--- a/src/AccountsService.vala
+++ b/src/AccountsService.vala
@@ -86,7 +86,6 @@ public interface SettingsDaemon.AccountsService : Object {
 
 [DBus (name = "io.elementary.pantheon.AccountsService")]
 public interface Pantheon.AccountsService : Object {
-    public abstract int prefers_color_scheme { get; set; }
     public abstract int prefers_accent_color { get; set; }
 }
 

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -15,11 +15,11 @@ public sealed class SettingsDaemon.Application : Gtk.Application {
     private Backends.MouseSettings mouse_settings;
     private Backends.InterfaceSettings interface_settings;
     private Backends.NightLightSettings night_light_settings;
-    private Backends.PrefersColorSchemeSettings prefers_color_scheme_settings;
     private Backends.AccentColorManager accent_color_manager;
 
     private Backends.Housekeeping housekeeping;
     private Backends.PowerProfilesSync power_profiles_sync;
+    private Backends.PrefersColorSchemeSettings prefers_color_scheme_settings;
 
     private const string FDO_ACCOUNTS_NAME = "org.freedesktop.Accounts";
     private const string FDO_ACCOUNTS_PATH = "/org/freedesktop/Accounts";
@@ -56,6 +56,7 @@ public sealed class SettingsDaemon.Application : Gtk.Application {
 
         housekeeping = new Backends.Housekeeping ();
         power_profiles_sync = new Backends.PowerProfilesSync ();
+        prefers_color_scheme_settings = new Backends.PrefersColorSchemeSettings ();
 
         var check_firmware_updates_action = new GLib.SimpleAction ("check-firmware-updates", null);
         check_firmware_updates_action.activate.connect (check_firmware_updates);
@@ -122,7 +123,6 @@ public sealed class SettingsDaemon.Application : Gtk.Application {
 
         try {
             pantheon_service = yield connection.get_proxy (FDO_ACCOUNTS_NAME, path, GET_INVALIDATED_PROPERTIES);
-            prefers_color_scheme_settings = new Backends.PrefersColorSchemeSettings (pantheon_service);
             accent_color_manager = new Backends.AccentColorManager (pantheon_service);
         } catch {
             warning ("Unable to get pantheon's AccountsService proxy, color scheme preference may be incorrect");

--- a/src/Backends/PrefersColorSchemeSettings.vala
+++ b/src/Backends/PrefersColorSchemeSettings.vala
@@ -20,8 +20,6 @@
 */
 
 public class SettingsDaemon.Backends.PrefersColorSchemeSettings : Object {
-    public unowned Pantheon.AccountsService accounts_service { get; construct; }
-
     private const string COLOR_SCHEME = "color-scheme";
     private const string DARK_SCHEDULE = "prefer-dark-schedule";
     private const string DARK_SCHEDULE_SNOOZED = "prefer-dark-schedule-snoozed";
@@ -31,10 +29,6 @@ public class SettingsDaemon.Backends.PrefersColorSchemeSettings : Object {
     private double sunset = -1.0;
 
     private uint time_id = 0;
-
-    public PrefersColorSchemeSettings (Pantheon.AccountsService accounts_service) {
-        Object (accounts_service: accounts_service);
-    }
 
     construct {
         color_settings = new Settings ("io.elementary.settings-daemon.prefers-color-scheme");
@@ -134,8 +128,6 @@ public class SettingsDaemon.Backends.PrefersColorSchemeSettings : Object {
         ) {
             color_settings.set_boolean (DARK_SCHEDULE_SNOOZED, true);
         }
-
-        accounts_service.prefers_color_scheme = color_scheme;
 
         var mutter_settings = new GLib.Settings ("org.gnome.desktop.interface");
         mutter_settings.set_enum ("color-scheme", color_scheme);


### PR DESCRIPTION
I guess we stored it in AccountsService because there was no settings portal in OS 6 and we making dbus flatpak hole is easier than gsettings one. Right now we store color-scheme preference in both, let's just use gsettings and I'll make a separate dark-style sync for greeter later