### PR TITLE
Cache dynamic accent color in account settings and use it in Portal

### DIFF
--- a/data/io.elementary.SettingsDaemon.AccountsService.xml
+++ b/data/io.elementary.SettingsDaemon.AccountsService.xml
@@ -84,6 +84,10 @@
       <annotation name="org.freedesktop.Accounts.DefaultValue" value="true"/>
     </property>
 
+    <property name="AccentColor" type="i" access="readwrite">
+      <annotation name="org.freedesktop.Accounts.DefaultValue" value="1"/>
+    </property>
+
     <property name="CursorBlink" type="b" access="readwrite">
       <annotation name="org.freedesktop.Accounts.DefaultValue" value="true"/>
     </property>

--- a/src/AccountsService.vala
+++ b/src/AccountsService.vala
@@ -56,6 +56,7 @@ public interface SettingsDaemon.AccountsService : Object {
     public abstract bool touchpad_two_finger_scrolling { get; set; }
 
     /* Interface */
+    public abstract int accent_color { get; set; }
     public abstract bool cursor_blink { get; set; }
     public abstract int cursor_blink_time { get; set; }
     public abstract int cursor_blink_timeout { get; set; }

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -125,7 +125,7 @@ public sealed class SettingsDaemon.Application : Gtk.Application {
         try {
             pantheon_service = yield connection.get_proxy (FDO_ACCOUNTS_NAME, path, GET_INVALIDATED_PROPERTIES);
             prefers_color_scheme_settings = new Backends.PrefersColorSchemeSettings (pantheon_service);
-            accent_color_manager = new Backends.AccentColorManager (pantheon_service);
+            accent_color_manager = new Backends.AccentColorManager (pantheon_service, accounts_service);
         } catch {
             warning ("Unable to get pantheon's AccountsService proxy, color scheme preference may be incorrect");
         }


### PR DESCRIPTION
Fixes https://github.com/elementary/settings-daemon/issues/149

Changes:
- Set Gtk theme here instead of in settings plug
- Cache calculated dynamic accent color in out settings account service and use it in portal, which fixes https://github.com/elementary/settings-daemon/issues/149. And it can be used to fix https://github.com/elementary/greeter/issues/689