### PR TITLE
Fix housekeeping

### DIFF
--- a/src/Backends/Housekeeping.vala
+++ b/src/Backends/Housekeeping.vala
@@ -140,7 +140,7 @@ public class SettingsDaemon.Backends.Housekeeping : Object {
         public int clean_after_days { private get; public construct; }
 
         public bool is_disabled { get {
-            return (!clean_downloads && !clean_screenshots) || clean_after_days < 1;
+            return (!clean_downloads && !clean_screenshots && !clean_temp && !clean_trash) || clean_after_days < 1;
         }}
 
         public CleanupConfig (Settings settings) {


### PR DESCRIPTION
Fixes a bug introduced in https://github.com/elementary/settings-daemon/pull/143

If you enable housekeeping for temp and trashed files only, it won't work because is_disabled was never updated to account for these options.