### PR TITLE
Housekeeping: Clean systemd's logs and tmp directories

### DIFF
--- a/src/Backends/Housekeeping.vala
+++ b/src/Backends/Housekeeping.vala
@@ -183,6 +183,8 @@ public class SettingsDaemon.Backends.Housekeeping : Object {
             if (clean_temp) {
                 var temp_dir = Environment.get_tmp_dir ();
                 lines += template.printf (temp_dir, clean_after_days);
+                lines += template.printf ("/var/log", clean_after_days);
+                lines += template.printf ("/var/tmp", clean_after_days);
             }
 
             if (clean_trash) {

--- a/src/Backends/Housekeeping.vala
+++ b/src/Backends/Housekeeping.vala
@@ -140,7 +140,7 @@ public class SettingsDaemon.Backends.Housekeeping : Object {
         public int clean_after_days { private get; public construct; }
 
         public bool is_disabled { get {
-            return (!clean_downloads && !clean_screenshots) || clean_after_days < 1;
+            return (!clean_downloads && !clean_screenshots && !clean_temp && !clean_trash) || clean_after_days < 1;
         }}
 
         public CleanupConfig (Settings settings) {


### PR DESCRIPTION
Fixes https://github.com/elementary/settings-daemon/issues/191
Includes and requires https://github.com/elementary/settings-daemon/pull/195

/var/log was requested here: https://github.com/elementary/settings-daemon/issues/191
/var/tmp is a temporary directory where some stuff e.g. coredumps are located. On my install they took about 30GB of storage, so I think we definitely should clean it