### PR TITLE
SystemUpdate: Use systemd timer for initial and daily update check

### DIFF
--- a/data/io.elementary.settings-daemon.gschema.xml
+++ b/data/io.elementary.settings-daemon.gschema.xml
@@ -108,11 +108,6 @@
       <summary>When updates were last refreshed</summary>
       <description>When the cache was last refreshed and checked for updates in unix utc.</description>
     </key>
-    <key type="x" name="refresh-interval">
-      <default>86400</default>
-      <summary>How often to check for updates</summary>
-      <description>How often to check for updates in seconds.</description>
-    </key>
   </schema>
 
   <schema path="/io/elementary/settings-daemon/power/" id="io.elementary.settings-daemon.power">

--- a/data/io.elementary.settings-daemon.system-update.service.in
+++ b/data/io.elementary.settings-daemon.system-update.service.in
@@ -1,0 +1,8 @@
+[Unit]
+Description=Check for system updates daily
+ConditionACPower=true
+After=network.target network-online.target systemd-networkd.service NetworkManager.service connman.service
+
+[Service]
+Type=oneshot
+ExecStart=@busctl_path@ --user call io.elementary.settings-daemon /io/elementary/settings_daemon io.elementary.settings_daemon.SystemUpdate CheckForUpdates bb false true

--- a/data/io.elementary.settings-daemon.system-update.timer
+++ b/data/io.elementary.settings-daemon.system-update.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Check for system updates daily
+
+[Timer]
+OnCalendar=daily
+OnStartupSec=60
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/data/meson.build
+++ b/data/meson.build
@@ -71,4 +71,16 @@ if systemd_system_unit_dir != 'no'
         meson.project_name() + '.check-for-firmware-updates.timer',
         install_dir: systemd_system_unit_dir
     )
+
+    configure_file(
+        input: meson.project_name() + '.system-update.service.in',
+        output: meson.project_name() + '.system-update.service',
+        configuration: service_config,
+        install_dir: systemd_system_unit_dir
+    )
+
+    install_data(
+        meson.project_name() + '.system-update.timer',
+        install_dir: systemd_system_unit_dir
+    )
 endif

--- a/data/meson.build
+++ b/data/meson.build
@@ -47,11 +47,15 @@ i18n.merge_file(
 
 busctl_path = get_option('busctlpath')
 systemd_system_unit_dir = get_option('systemdsystemunitdir')
+systemd_user_unit_dir = get_option('systemduserunitdir')
 
-if systemd_system_unit_dir != 'no'
+if systemd_system_unit_dir != 'no' and systemd_systemduserunitdir != 'no'
     systemd = dependency('systemd')
     if systemd_system_unit_dir == ''
         systemd_system_unit_dir = systemd.get_variable('systemdsystemunitdir', pkgconfig_define: ['rootprefix', prefix])
+    endif
+    if systemd_user_unit_dir == ''
+        systemd_user_unit_dir = systemd.get_variable('systemduserunitdir', pkgconfig_define: ['prefix', prefix])
     endif
     if busctl_path == ''
         busctl_path = systemd.get_variable('prefix') / 'bin' / 'busctl'
@@ -76,11 +80,11 @@ if systemd_system_unit_dir != 'no'
         input: meson.project_name() + '.system-update.service.in',
         output: meson.project_name() + '.system-update.service',
         configuration: service_config,
-        install_dir: systemd_system_unit_dir
+        install_dir: systemd_user_unit_dir
     )
 
     install_data(
         meson.project_name() + '.system-update.timer',
-        install_dir: systemd_system_unit_dir
+        install_dir: systemd_user_unit_dir
     )
 endif

--- a/data/meson.build
+++ b/data/meson.build
@@ -49,7 +49,7 @@ busctl_path = get_option('busctlpath')
 systemd_system_unit_dir = get_option('systemdsystemunitdir')
 systemd_user_unit_dir = get_option('systemduserunitdir')
 
-if systemd_system_unit_dir != 'no' and systemd_systemduserunitdir != 'no'
+if systemd_system_unit_dir != 'no' and systemd_user_unit_dir != 'no'
     systemd = dependency('systemd')
     if systemd_system_unit_dir == ''
         systemd_system_unit_dir = systemd.get_variable('systemdsystemunitdir', pkgconfig_define: ['rootprefix', prefix])

--- a/src/Backends/SystemUpdate.vala
+++ b/src/Backends/SystemUpdate.vala
@@ -58,13 +58,6 @@ public class SettingsDaemon.Backends.SystemUpdate : Object {
         } catch (Error e) {
             warning ("Couldn't determine last offline results: %s", e.message);
         }
-
-        check_for_updates.begin (false, true);
-
-        Timeout.add_seconds ((uint) settings.get_int64 ("refresh-interval"), () => {
-            check_for_updates.begin (false, true);
-            return Source.CONTINUE;
-        });
     }
 
     public async void check_for_updates (bool force, bool notify) throws DBusError, IOError {


### PR DESCRIPTION
Fixes #158
Closes #177

## TODO
- [ ] The timer is not enabled (started automatically on login) unless you manually enable it for some reason :shrug:

```
user@elementary-8:~$ systemctl --user status io.elementary.settings-daemon.system-update.timer 
○ io.elementary.settings-daemon.system-update.timer - Check for system updates daily
     Loaded: loaded (/usr/lib/systemd/user/io.elementary.settings-daemon.system-update.timer; disabled; preset: enabled)
     Active: inactive (dead)
    Trigger: n/a
   Triggers: ● io.elementary.settings-daemon.system-update.service
user@elementary-8:~$ systemctl enable --user io.elementary.settings-daemon.system-update.timer 
Created symlink /home/user/.config/systemd/user/timers.target.wants/io.elementary.settings-daemon.system-update.timer → /usr/lib/systemd/user/io.elementary.settings-daemon.system-update.timer.
user@elementary-8:~$
```