### PR TITLE
AccentColorManager: Prevent out of range access to themes array

### DIFF
--- a/src/Backends/AccentColorManager.vala
+++ b/src/Backends/AccentColorManager.vala
@@ -85,13 +85,15 @@ public class SettingsDaemon.Backends.AccentColorManager : Object {
     private void update_accent_color () {
         Theme? new_theme = null;
         var prefers_accent_color = pantheon_accounts_service.prefers_accent_color;
+        if (prefers_accent_color < 0 || prefers_accent_color - 1 >= themes.length) {
+            critical ("Incorrect accent color in pantheon accounts service. color=%d", prefers_accent_color);
+            return;
+        }
+
         if (prefers_accent_color == 0) {
             new_theme = get_dynamic_accent_color_theme_name ();
-        } else if (prefers_accent_color < themes.length + 1) {
-            new_theme = themes[prefers_accent_color - 1];
         } else {
-            critical ("Incorrect accent color in pantheon accounts service");
-            return;
+            new_theme = themes[prefers_accent_color - 1];
         }
 
         interface_settings.set_string ("gtk-theme", new_theme.stylesheet);


### PR DESCRIPTION
This would never happen but the current code causes out of range access to `themes` array if `prefers_accent_color`, which is int, happens to be a value under 0.

Also refactor to be a early return and improve the log message—show the invalid value—while I'm here.
