### PR TITLE
InterfaceSettings: Update RDNN of Power Panel

### DIFF
--- a/src/Backends/InterfaceSettings.vala
+++ b/src/Backends/InterfaceSettings.vala
@@ -74,6 +74,11 @@ public class SettingsDaemon.Backends.InterfaceSettings : GLib.Object {
         var wingpanel_power_schema = SettingsSchemaSource.get_default ().lookup ("io.elementary.panel.power", true);
         if (wingpanel_power_schema != null && wingpanel_power_schema.has_key (SHOW_PERCENTAGE)) {
             wingpanel_power_settings = new GLib.Settings ("io.elementary.panel.power");
+        } else {
+            wingpanel_power_schema = SettingsSchemaSource.get_default ().lookup ("io.elementary.desktop.wingpanel.power", true);
+            if (wingpanel_power_schema != null && wingpanel_power_schema.has_key (SHOW_PERCENTAGE)) {
+                wingpanel_power_settings = new GLib.Settings ("io.elementary.desktop.wingpanel.power");
+            }
         }
 
         sync_gsettings_to_accountsservice ();

--- a/src/Backends/InterfaceSettings.vala
+++ b/src/Backends/InterfaceSettings.vala
@@ -71,9 +71,9 @@ public class SettingsDaemon.Backends.InterfaceSettings : GLib.Object {
             wingpanel_settings = new GLib.Settings ("io.elementary.desktop.wingpanel");
         }
 
-        var wingpanel_power_schema = SettingsSchemaSource.get_default ().lookup ("io.elementary.desktop.wingpanel.power", true);
+        var wingpanel_power_schema = SettingsSchemaSource.get_default ().lookup ("io.elementary.panel.power", true);
         if (wingpanel_power_schema != null && wingpanel_power_schema.has_key (SHOW_PERCENTAGE)) {
-            wingpanel_power_settings = new GLib.Settings ("io.elementary.desktop.wingpanel.power");
+            wingpanel_power_settings = new GLib.Settings ("io.elementary.panel.power");
         }
 
         sync_gsettings_to_accountsservice ();


### PR DESCRIPTION
Same reason with https://github.com/elementary/panel-power/pull/302. We switched RDNN of Power Panel from `io.elementary.desktop.wingpanel.power` to `io.elementary.panel.power` in https://github.com/elementary/panel-power/pull/285.
